### PR TITLE
[#169988032] Showing persmissions screen

### DIFF
--- a/android/src/main/java/com/reactnative/samsunghealth/ConnectionListener.java
+++ b/android/src/main/java/com/reactnative/samsunghealth/ConnectionListener.java
@@ -53,32 +53,28 @@ public class ConnectionListener implements
     private Callback mErrorCallback;
     private SamsungHealthModule mModule;
     private HealthConnectionErrorResult mConnError;
+    private Boolean mRequestPermission;
 
     private static final String REACT_MODULE = "RNSamsungHealth";
 
     public Set<PermissionKey> mKeySet;
 
-    public ConnectionListener(SamsungHealthModule module, Callback error, Callback success)
+    public ConnectionListener(SamsungHealthModule module, Callback error, Callback success, Boolean requestPermissions)
     {
         mModule = module;
         mErrorCallback = error;
         mSuccessCallback = success;
         mKeySet = new HashSet<PermissionKey>();
+        mRequestPermission = requestPermissions;
     }
     
     public void addReadPermission(String name)
     {
-        // mKeySet.add(new PermissionKey(name, PermissionType.READ));
-        // mKeySet.add(new PermissionKey(SamsungHealthModule.STEP_DAILY_TREND_TYPE, PermissionType.READ));
-
         mKeySet.add(new PermissionKey("com.samsung.shealth.step_daily_trend", PermissionType.READ));
-        mKeySet.add(new PermissionKey("com.samsung.health.step_count", PermissionType.READ));
         mKeySet.add(new PermissionKey("com.samsung.health.weight", PermissionType.READ));
         mKeySet.add(new PermissionKey("com.samsung.health.height", PermissionType.READ));
         mKeySet.add(new PermissionKey("com.samsung.health.heart_rate", PermissionType.READ));
-        mKeySet.add(new PermissionKey("com.samsung.health.blood_pressure", PermissionType.READ));
         mKeySet.add(new PermissionKey("com.samsung.health.sleep", PermissionType.READ));
-        mKeySet.add(new PermissionKey("com.samsung.health.body_temperature", PermissionType.READ));
         mKeySet.add(new PermissionKey("com.samsung.health.body_fat", PermissionType.READ));
         mKeySet.add(new PermissionKey("com.samsung.health.user_profile", PermissionType.READ));
         mKeySet.add(new PermissionKey("com.samsung.health.exercise", PermissionType.READ));
@@ -99,7 +95,7 @@ public class ConnectionListener implements
             // Check whether the permissions that this application needs are acquired
             Map<PermissionKey, Boolean> resultMap = pmsManager.isPermissionAcquired(mKeySet);
 
-            if (resultMap.containsValue(Boolean.FALSE)) {
+            if (resultMap.containsValue(Boolean.FALSE) && mRequestPermission) {
                 // Request the permission for reading step counts if it is not acquired
                 pmsManager.requestPermissions(mKeySet, mModule.getContext().getCurrentActivity()).setResultListener(
                     new PermissionListener(mModule, mErrorCallback, mSuccessCallback)

--- a/android/src/main/java/com/reactnative/samsunghealth/SamsungHealthModule.java
+++ b/android/src/main/java/com/reactnative/samsunghealth/SamsungHealthModule.java
@@ -428,6 +428,7 @@ public class SamsungHealthModule extends ReactContextBaseJavaModule implements
             }
         } catch (Exception e) {
             Log.d(REACT_MODULE, "Do not have permission to get user profile");
+            error.invoke("Samsung Health: Getting data of birth failed");
         }
     }
 
@@ -447,6 +448,7 @@ public class SamsungHealthModule extends ReactContextBaseJavaModule implements
             }
         } catch (Exception e) {
             Log.d(REACT_MODULE, "Do not have permission to get user profile");
+            error.invoke("Samsung Health: Getting gender failed");
         }
     }
 

--- a/android/src/main/java/com/reactnative/samsunghealth/SamsungHealthModule.java
+++ b/android/src/main/java/com/reactnative/samsunghealth/SamsungHealthModule.java
@@ -133,9 +133,9 @@ public class SamsungHealthModule extends ReactContextBaseJavaModule implements
     }
 
     @ReactMethod
-    public void connect(ReadableArray permissions, Callback error, Callback success)
+    public void connect(Boolean requestPermission, ReadableArray permissions, Callback error, Callback success)
     {
-        ConnectionListener listener = new ConnectionListener(this, error, success);
+        ConnectionListener listener = new ConnectionListener(this, error, success, requestPermission);
         for (int i = 0; i < permissions.size(); i++) {
             listener.addReadPermission(permissions.getString(i));
         }
@@ -180,7 +180,7 @@ public class SamsungHealthModule extends ReactContextBaseJavaModule implements
         } catch (Exception e) {
             Log.e(REACT_MODULE, e.getClass().getName() + " - " + e.getMessage());
             Log.e(REACT_MODULE, "Getting step count fails.");
-            error.invoke("Getting step count fails.");
+            error.invoke("Samsung Health: Getting step count failed.");
         }
     }
 
@@ -208,7 +208,7 @@ public class SamsungHealthModule extends ReactContextBaseJavaModule implements
         } catch (Exception e) {
             Log.e(REACT_MODULE, e.getClass().getName() + " - " + e.getMessage());
             Log.e(REACT_MODULE, "Getting Height fails.");
-            error.invoke("Getting Height fails.");
+            error.invoke("Samsung Health: Getting Height failed.");
         }
     }
 
@@ -239,7 +239,7 @@ public class SamsungHealthModule extends ReactContextBaseJavaModule implements
         } catch (Exception e) {
             Log.e(REACT_MODULE, e.getClass().getName() + " - " + e.getMessage());
             Log.e(REACT_MODULE, "Getting BloodPressure fails.");
-            error.invoke("Getting BloodPressure fails.");
+            error.invoke("Samsung Health: Getting BloodPressure failed.");
         }
     }
 
@@ -268,7 +268,7 @@ public class SamsungHealthModule extends ReactContextBaseJavaModule implements
         } catch (Exception e) {
             Log.e(REACT_MODULE, e.getClass().getName() + " - " + e.getMessage());
             Log.e(REACT_MODULE, "Getting BodyTemperature fails.");
-            error.invoke("Getting BodyTemperature fails.");
+            error.invoke("Samsung Health: Getting BodyTemperature failed.");
         }
     }
 
@@ -294,8 +294,8 @@ public class SamsungHealthModule extends ReactContextBaseJavaModule implements
             resolver.read(request).setResultListener(new HealthDataResultListener(this, error, success));
         } catch (Exception e) {
             Log.e(REACT_MODULE, e.getClass().getName() + " - " + e.getMessage());
-            Log.e(REACT_MODULE, "Getting weight body fay fails.");
-            error.invoke("Getting weight body fat fails.");
+            Log.e(REACT_MODULE, "Getting weight body fat fails.");
+            error.invoke("Samsung Health: Getting weight body fat failed.");
         }
     }
 
@@ -323,7 +323,7 @@ public class SamsungHealthModule extends ReactContextBaseJavaModule implements
         } catch (Exception e) {
             Log.e(REACT_MODULE, e.getClass().getName() + " - " + e.getMessage());
             Log.e(REACT_MODULE, "Getting HeartRate fails.");
-            error.invoke("Getting HeartRate fails.");
+            error.invoke("Samsung Health: Getting HeartRate failed.");
         }
     }
 
@@ -351,7 +351,7 @@ public class SamsungHealthModule extends ReactContextBaseJavaModule implements
         } catch (Exception e) {
             Log.e(REACT_MODULE, e.getClass().getName() + " - " + e.getMessage());
             Log.e(REACT_MODULE, "Getting Sleep fails.");
-            error.invoke("Getting Sleep fails.");
+            error.invoke("Samsung Health: Getting Sleep failed.");
         }
     }
 
@@ -380,7 +380,7 @@ public class SamsungHealthModule extends ReactContextBaseJavaModule implements
         } catch (Exception e) {
             Log.e(REACT_MODULE, e.getClass().getName() + " - " + e.getMessage());
             Log.e(REACT_MODULE, "Getting weight fails.");
-            error.invoke("Getting weight fails.");
+            error.invoke("Samsung Health: Getting weight failed.");
         }
     }
 
@@ -408,7 +408,7 @@ public class SamsungHealthModule extends ReactContextBaseJavaModule implements
         } catch (Exception e) {
             Log.e(REACT_MODULE, e.getClass().getName() + " - " + e.getMessage());
             Log.e(REACT_MODULE, "Getting TotalCholesterol fails.");
-            error.invoke("Getting TotalCholesterol fails.");
+            error.invoke("Samsung Health: Getting TotalCholesterol failed");
         }
     }
 
@@ -476,8 +476,8 @@ public class SamsungHealthModule extends ReactContextBaseJavaModule implements
             resolver.read(request).setResultListener(new HealthDataResultListener(this, error, success));
         } catch (Exception e) {
             Log.e(REACT_MODULE, e.getClass().getName() + " - " + e.getMessage());
-            Log.e(REACT_MODULE, "Getting TotalCholesterol fails.");
-            error.invoke("Getting TotalCholesterol fails.");
+            Log.e(REACT_MODULE, "Getting workout fails.");
+            error.invoke("Samsung Health: Getting workouts failed");
         }
     }
 
@@ -518,7 +518,7 @@ public class SamsungHealthModule extends ReactContextBaseJavaModule implements
                 Log.d(REACT_MODULE, "StepCountObserver onChanged");
                 stepSuccessCallback.invoke("steps changed");
             }
-            stepErrorCallback.invoke("getting step change failed");
+            stepErrorCallback.invoke("Getting step change notification failed");
         }
     };
 }

--- a/index.android.js
+++ b/index.android.js
@@ -6,8 +6,9 @@ import {
 const samsungHealth = NativeModules.RNSamsungHealth;
 
 class RNSamsungHealth {
-  authorize(callback) {
+  authorize(requestPermission, callback) {
     samsungHealth.connect(
+      requestPermission,
       [samsungHealth.STEP_COUNT],
       (msg) => { callback(msg, false); },
       (res) => { callback(false, res); },


### PR DESCRIPTION
> Only showing the permissions screen when first connecting, not on every sync (would happen if there was a permission item that was not granted)
> Fixed a problem where failing to get date of birth or gender (like with a permissions failure) would not send the error callback, preventing sync from completing
> Updated the StepCountReporter to use daily step trend, so we only need to ask for one step permission